### PR TITLE
Fix nil value bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 1.2.3 - 2016.06.09
+
+* [BUGFIX] Don't raise errors on `Yt::Annotations.for` for some videos in Barbie channel
+
 ## 1.2.2 - 2016.05.16
 
 * [BUGFIX] Do not raise errors from videos with info cards.

--- a/lib/yt/annotations/for.rb
+++ b/lib/yt/annotations/for.rb
@@ -51,7 +51,7 @@ module Yt
         highlights, others = annotations.partition{|a| a['type'] == 'highlight'}
         highlights.each do |highlight|
           match = others.find do |a|
-            a.fetch('segment', {})['spaceRelative'] == highlight['id']
+            (a['segment'] || {})['spaceRelative'] == highlight['id']
           end
           match.merge! highlight if match
         end

--- a/lib/yt/annotations/version.rb
+++ b/lib/yt/annotations/version.rb
@@ -1,5 +1,5 @@
 module Yt
   module Annotations
-    VERSION = '1.2.2'
+    VERSION = '1.2.3'
   end
 end


### PR DESCRIPTION
YouTube made change, for some annotations `"segment"` key does exist **and** has value `nil`.

Before 

``` rb
> Yt::Annotations.for('uuRDGpKUWZY')
# NoMethodError: undefined method `[]' for nil:NilClass
```

After

``` rb
> Yt::Annotations.for('uuRDGpKUWZY')
# => [#<Yt::Annotations::Card:0x007fd399c15268 @text="Click Here to get stylin'!",...
```
