### PR TITLE
Bump required ruby version 2.2.2 to run ActiveSupport 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.0.0
+  - 2.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 1.3.0 - 2016.07.11
+
+* [BUGFIX] Bump Ruby version to 2.2.2 to make it work with ActiveSupport 5
+
 ## 1.2.3 - 2016.06.09
 
 * [BUGFIX] Don't raise errors on `Yt::Annotations.for` for some videos in Barbie channel

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ annotations.first.link
 How to install
 ==============
 
-Yt::Annotations requires **Ruby 2.0 or higher**.
+Yt::Annotations requires **Ruby 2.2.2 or higher**.
 
 To include in your project, add `gem 'yt-annotations', ~> '1.0'` to the `Gemfile` file of your Ruby project.
 

--- a/lib/yt/annotations/version.rb
+++ b/lib/yt/annotations/version.rb
@@ -1,5 +1,5 @@
 module Yt
   module Annotations
-    VERSION = '1.2.3'
+    VERSION = '1.3.0'
   end
 end

--- a/yt-annotations.gemspec
+++ b/yt-annotations.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/fullscreen/yt-annotations'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = '>= 2.0'
+  spec.required_ruby_version = '>= 2.2.2'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'


### PR DESCRIPTION
Travis build failed today, because ActiveSupport 5 wasn't working with Ruby 2.0.0
