### PR TITLE
Fix endscreen for video and playlist style

### DIFF
--- a/lib/yt/annotations/end_screen.rb
+++ b/lib/yt/annotations/end_screen.rb
@@ -28,13 +28,21 @@ module Yt
           when 'WEBSITE'
             json['endpoint']['urlEndpoint']['url']
           when 'PLAYLIST'
-            "https://www.youtube.com/watch?v=" +
-            json['endpoint']['watchEndpoint']['videoId'] +
-            "&list=" +
-            json['endpoint']['watchEndpoint']['playlistId']
+            if json['endpoint']['watchEndpoint']
+              "https://www.youtube.com/watch?v=" +
+              json['endpoint']['watchEndpoint']['videoId'] +
+              "&list=" +
+              json['endpoint']['watchEndpoint']['playlistId']
+            else
+              "https://www.youtube.com" + json['endpoint']['urlEndpoint']['url']
+            end
           when 'VIDEO'
-            "https://www.youtube.com/watch?v=" +
-            json['endpoint']['watchEndpoint']['videoId']
+            if json['endpoint']['watchEndpoint']
+              "https://www.youtube.com/watch?v=" +
+              json['endpoint']['watchEndpoint']['videoId']
+            else
+              "https://www.youtube.com" + json['endpoint']['urlEndpoint']['url']
+            end
           when 'CHANNEL'
             if json['isSubscribe']
               "https://www.youtube.com/channel/" +


### PR DESCRIPTION
currently `json['endpoint']['watchEndpoint']['videoId']` raises `NoMethodError: undefined method '[]' for nil:NilClass`

Because YouTube changed XML into like this
`"endpoint"=>{"urlEndpoint"=>{"url"=>"/watch?v=9bZkp7q19f0"}}`

so by this change we use `json['endpoint']['urlEndpoint']['url']`